### PR TITLE
Updates readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# svelte-json-tree
+# @sveltejs/svelte-json-tree
 
-![version](https://img.shields.io/npm/v/svelte-json-tree?style=flat-square) ![MIT License](https://img.shields.io/npm/l/svelte-json-tree?style=flat-square)
+![version](https://img.shields.io/npm/v/@sveltejs/svelte-json-tree?style=flat-square) ![MIT License](https://img.shields.io/npm/l/@sveltejs/svelte-json-tree?style=flat-square)
 
 ![svelte-json-tree](./images/screenshot.png)
 
@@ -14,10 +14,10 @@ Use [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/lang/en) to inst
 
 ```sh
 # npm
-npm install --save svelte-json-tree
+npm install --save @sveltejs/svelte-json-tree
 
 # yarn
-yarn add svelte-json-tree
+yarn add @sveltejs/svelte-json-tree
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ With Svelte:
 
 ```html
 <script>
-  import JSONTree from 'svelte-json-tree';
+  import JSONTree from '@sveltejs/svelte-json-tree';
   // your json data to view
   const value = {
     array: [1, 2, 3],
@@ -43,7 +43,7 @@ With Svelte:
 Without Svelte:
 
 ```js
-const JSONTree = require('svelte-json-tree');
+const JSONTree = require('@sveltejs/svelte-json-tree');
 const jsonTree = new JSONTree({
   target: document.body,
   props: {
@@ -57,7 +57,7 @@ jsonTree.$set({ value: ['1'] });
 
 ## Overriding Styles
 
-**svelte-json-tree** uses the following CSS variables to theme:
+**@sveltejs/svelte-json-tree** uses the following CSS variables to theme:
 
 ```css
 /* color */
@@ -93,4 +93,4 @@ To overwrite the style, specify the css variables on the parent:
 
 ## License
 
-[MIT](https://github.com/tanhauhau/svelte-json-tree/blob/master/LICENSE)
+[MIT](https://github.com/sveltejs/svelte-json-tree/blob/master/LICENSE)

--- a/src/routes/(docs)/+page.svelte
+++ b/src/routes/(docs)/+page.svelte
@@ -5,12 +5,12 @@
 <h1>svelte-json-tree</h1>
 
 <div>
-  <a target="_blank" href="https://npmjs.com/svelte-json-tree">
-    <img alt="npm-version" src="https://img.shields.io/npm/v/svelte-json-tree.svg" />
+  <a target="_blank" href="https://npmjs.com/sveltejs/svelte-json-tree">
+    <img alt="npm-version" src="https://img.shields.io/npm/v/sveltejs/svelte-json-tree.svg" />
   </a>
   &nbsp;
-  <a target="_blank" href="https://github.com/tanhauhau/svelte-json-tree">
-    <img alt="github" src="https://img.shields.io/github/stars/tanhauhau/svelte-json-tree?style=social" />
+  <a target="_blank" href="https://github.com/sveltejs/svelte-json-tree">
+    <img alt="github" src="https://img.shields.io/github/stars/sveltejs/svelte-json-tree?style=social" />
   </a>
 </div>
 

--- a/src/routes/(docs)/docs/+page.md
+++ b/src/routes/(docs)/docs/+page.md
@@ -9,20 +9,20 @@
 With `npm`
 
 ```sh
-npm install svelte-json-tree
+npm install @sveltejs/svelte-json-tree
 ```
 
 With `yarn`
 
 ```sh
-yarn add svelte-json-tree
+yarn add @sveltejs/svelte-json-tree
 ```
 
 ## Use it
 
 ```svelte
 <script>
-  import JsonTree from 'svelte-json-tree';
+  import JsonTree from '@sveltejs/svelte-json-tree';
   let value = {
     message: 'hello world',
     item: [1, 2, 3],
@@ -214,10 +214,10 @@ You can set `shouldShowPreview` to `false` to hide it.
 
 ## ESM / Standalone / UMD
 
-You can import `svelte-json-tree` directly, without having to setting up plugins to transform `.svelte` code
+You can import `@sveltejs/svelte-json-tree` directly, without having to setting up plugins to transform `.svelte` code
 
 ```js
-import Jsontree from 'svelte-json-tree';
+import Jsontree from '@sveltejs/svelte-json-tree';
 
 new Jsontree({
   target: document.body,
@@ -228,7 +228,7 @@ new Jsontree({
 If you want to use it without installing `svelte`, use the **standalone** version
 
 ```js
-import Jsontree from 'svelte-json-tree/standalone';
+import Jsontree from '@sveltejs/svelte-json-tree/standalone';
 
 new Jsontree({
   target: document.body,


### PR DESCRIPTION
This fixes the Readme (and static files) to reference installing `@sveltejs/svelte-json-tree` instead of the base `svelte-json-tree`,